### PR TITLE
修正mssql查询和更新时生成语句的错误

### DIFF
--- a/library/think/db/builder/Sqlsrv.php
+++ b/library/think/db/builder/Sqlsrv.php
@@ -28,7 +28,7 @@ class Sqlsrv extends Builder
      */
     protected function parseOrder($order)
     {
-        return !empty($order) ? ' ORDER BY ' . $order[0] : ' ORDER BY rand()';
+        return !empty($order) ? ' ORDER BY ' . $order : ' ORDER BY rand()';
     }
 
     /**
@@ -76,5 +76,37 @@ class Sqlsrv extends Builder
         }
         return 'WHERE ' . $limitStr;
     }
+ /**
+     * 生成update SQL
+     * @access public
+     * @param array $fields 数据
+     * @param array $options 表达式
+     * @return string
+     */
+    public function update($data, $options)
+    {
+        $table = $this->parseTable($options['table']);
+        $data  = $this->parseData($data, $options);
+        if (empty($data)) {
+            return '';
+        }
+        foreach ($data as $key => $val) {
+            $set[] = $key . '=' . $val;
+        }
 
+        $sql = str_replace(
+            ['%TABLE%', '%SET%', '%JOIN%', '%WHERE%', '%ORDER%', '%LIMIT%', '%LOCK%', '%COMMENT%'],
+            [
+                $this->parseTable($options['table']),
+                implode(',', $set),
+                $this->parseJoin($options['join']),
+                $this->parseWhere($options['where'], $options['table']),
+                '',
+                $this->parseLimit($options['limit']),
+                $this->parseLimit($options['lock']),
+                $this->parseComment($options['comment']),
+            ], $this->updateSql);
+
+        return $sql;
+    }
 }


### PR DESCRIPTION
带order参数查询时，取值错误，取的$order[0]内容是第一个字母r。
生成update语句时，ORDER应该替换成空(MSSQL的update语句中不支持order)